### PR TITLE
Migration from python2 to python3

### DIFF
--- a/dcmanagerclient/api/base.py
+++ b/dcmanagerclient/api/base.py
@@ -75,7 +75,7 @@ class ResourceManager(object):
         json_objects = [json_response_key[item] for item in json_response_key]
         resource = []
         for json_object in json_objects:
-            data = json_object.get('usage').keys()
+            data = list(json_object.get('usage').keys())
             for values in data:
                 resource.append(self.resource_class(self, values,
                                 json_object['limits'][values],

--- a/dcmanagerclient/openstack/common/apiclient/base.py
+++ b/dcmanagerclient/openstack/common/apiclient/base.py
@@ -244,7 +244,7 @@ class ManagerWithFind(BaseManager):
         the Python side.
         """
         found = []
-        searches = kwargs.items()
+        searches = list(kwargs.items())
 
         for obj in self.list():
             try:
@@ -409,7 +409,7 @@ class Extension(HookableMixin):
 
     def _parse_extension_module(self):
         self.manager_class = None
-        for attr_name, attr_value in self.module.__dict__.items():
+        for attr_name, attr_value in list(self.module.__dict__.items()):
             if attr_name in self.SUPPORTED_HOOKS:
                 self.add_hook(attr_name, attr_value)
             else:
@@ -446,7 +446,7 @@ class Resource(object):
 
     def __repr__(self):
         reprkeys = sorted(k
-                          for k in self.__dict__.keys()
+                          for k in list(self.__dict__.keys())
                           if k[0] != '_' and k != 'manager')
         info = ", ".join("%s=%s" % (k, getattr(self, k)) for k in reprkeys)
         return "<%s %s>" % (self.__class__.__name__, info)

--- a/dcmanagerclient/openstack/common/apiclient/client.py
+++ b/dcmanagerclient/openstack/common/apiclient/client.py
@@ -363,7 +363,7 @@ class BaseClient(object):
                     "Must be one of: %(version_map)s") % \
                   {'api_name': api_name,
                    'version': version,
-                   'version_map': ', '.join(version_map.keys())
+                   'version_map': ', '.join(list(version_map.keys()))
                    }
             raise exceptions.UnsupportedVersion(msg)
 

--- a/dcmanagerclient/openstack/common/cliutils.py
+++ b/dcmanagerclient/openstack/common/cliutils.py
@@ -23,7 +23,7 @@
 # W0621: Redefining name %s from outer scope
 # pylint: disable=W0603,W0621
 
-from __future__ import print_function
+
 
 import getpass
 import inspect

--- a/dcmanagerclient/openstack/common/gettextutils.py
+++ b/dcmanagerclient/openstack/common/gettextutils.py
@@ -197,7 +197,7 @@ def install(domain, lazy=False):
         else:
             gettext.install(domain,
                             localedir=os.environ.get(localedir),
-                            unicode=True)
+                            str=True)
 
 
 class Message(six.text_type):
@@ -308,9 +308,9 @@ class Message(six.text_type):
             # Copy each item in case one does not support deep copy.
             params = {}
             if isinstance(self.params, dict):
-                for key, val in self.params.items():
+                for key, val in list(self.params.items()):
                     params[key] = self._copy_param(val)
-            for key, val in other.items():
+            for key, val in list(other.items()):
                 params[key] = self._copy_param(val)
         else:
             params = self._copy_param(other)

--- a/dcmanagerclient/shell.py
+++ b/dcmanagerclient/shell.py
@@ -98,13 +98,13 @@ class BashCompletionCommand(command.Command):
         commands = set()
         options = set()
 
-        for option, _action in self.app.parser._option_string_actions.items():
+        for option, _action in list(self.app.parser._option_string_actions.items()):
             options.add(option)
 
         for command_name, _cmd in self.app.command_manager:
             commands.add(command_name)
 
-        print(' '.join(commands | options))
+        print((' '.join(commands | options)))
 
 
 class DCManagerShell(app.App):
@@ -452,14 +452,14 @@ class DCManagerShell(app.App):
         self.client_manager = ClientManager()
 
     def _set_shell_commands(self, cmds_dict):
-        for k, v in cmds_dict.items():
+        for k, v in list(cmds_dict.items()):
             self.command_manager.add_command(k, v)
 
     def _clear_shell_commands(self):
         exclude_cmds = ['help', 'complete']
 
         cmds = self.command_manager.commands.copy()
-        for k, v in cmds.items():
+        for k, v in list(cmds.items()):
             if k not in exclude_cmds:
                 self.command_manager.commands.pop(k)
 

--- a/dcmanagerclient/utils.py
+++ b/dcmanagerclient/utils.py
@@ -38,7 +38,7 @@ def do_action_on_many(action, resources, success_msg, error_msg):
     for resource in resources:
         try:
             action(resource)
-            print(success_msg % resource)
+            print((success_msg % resource))
         except Exception as e:
             failure_flag = True
             print(e)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -23,14 +23,14 @@
 
 # -- Project information -----------------------------------------------------
 
-project = u'stx-distcloud-client'
-copyright = u'2018, StarlingX'
-author = u'StarlingX'
+project = 'stx-distcloud-client'
+copyright = '2018, StarlingX'
+author = 'StarlingX'
 
 # The short X.Y version
-version = u''
+version = ''
 # The full version, including alpha/beta/rc tags
-release = u'0.1'
+release = '0.1'
 
 
 # -- General configuration ---------------------------------------------------
@@ -136,8 +136,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'stx-distcloud-client.tex', u'stx-distcloud-client Documentation',
-     u'StarlingX', 'manual'),
+    (master_doc, 'stx-distcloud-client.tex', 'stx-distcloud-client Documentation',
+     'StarlingX', 'manual'),
 ]
 
 
@@ -146,7 +146,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'stx-distcloud-client', u'stx-distcloud-client Documentation',
+    (master_doc, 'stx-distcloud-client', 'stx-distcloud-client Documentation',
      [author], 1)
 ]
 
@@ -157,7 +157,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'stx-distcloud-client', u'stx-distcloud-client Documentation',
+    (master_doc, 'stx-distcloud-client', 'stx-distcloud-client Documentation',
      author, 'stx-distcloud-client', 'StarlingX Distributed Cloud Client.',
      'Miscellaneous'),
 ]

--- a/releasenotes/source/conf.py
+++ b/releasenotes/source/conf.py
@@ -194,8 +194,8 @@ latex_documents = [
     (
         'index',
         'stx-distcloud-clientreleasenotes.tex',
-        u'stx-distcloud-client Release Notes',
-        u'StarlingX',
+        'stx-distcloud-client Release Notes',
+        'StarlingX',
         'manual',
     ),
 ]
@@ -229,8 +229,8 @@ man_pages = [
     (
         'index',
         'stx-distcloud-clientreleasenotes',
-        u'stx-distcloud-client Release Notes',
-        [u'StarlingX'],
+        'stx-distcloud-client Release Notes',
+        ['StarlingX'],
         1,
     )
 ]
@@ -248,8 +248,8 @@ texinfo_documents = [
     (
         'index',
         'stx-distcloud-clientReleaseNotes',
-        u'stx-distcloud-client Release Notes',
-        u'StarlingX',
+        'stx-distcloud-client Release Notes',
+        'StarlingX',
         'stx-distcloud-clientreleasenotes',
         'StarlingX Distributed Cloud Client',
         'Miscellaneous',


### PR DESCRIPTION
This patches start the migration from python 2 to 3 by ussing the 2to3
tool

Signed-off-by: Victor Rodriguez <victor.rodriguez.bahena@intel.com>